### PR TITLE
Added support for Windows based file systems

### DIFF
--- a/src/TOC19/TOC19/Compatibility.java
+++ b/src/TOC19/TOC19/Compatibility.java
@@ -1,0 +1,42 @@
+package TOC19;
+
+/*
+*    TOC19 is a simple program to run TOC payments within a small group.
+*    Copyright (C) 2014  Jarrah Gosbell
+*
+*    This program is free software: you can redistribute it and/or modify
+*    it under the terms of the GNU General Public License as published by
+*    the Free Software Foundation, either version 3 of the License, or
+*    (at your option) any later version.
+*
+*    This program is distributed in the hope that it will be useful,
+*    but WITHOUT ANY WARRANTY; without even the implied warranty of
+*    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+*    GNU General Public License for more details.
+*
+*    You should have received a copy of the GNU General Public License
+*    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+/*
+* Author: Michael Brock
+* Student Number: z5056704
+* Class: Compatibility
+* Description: This class enables compatibility with Windows based operating systems and will handle all external file access.
+*/
+
+public class Compatibility {
+
+	/**
+	 * Get whether the host os is windows based
+	 * @return Whether the system is based on Windows
+	 */
+	public static boolean isWindows(){
+		return (System.getProperty("os.name").startsWith("Windows"));
+	}
+
+	public static String getFilePath(String file){
+		return isWindows()? System.getProperty("user.dir") + "\\" + file : file;
+	}
+
+}

--- a/src/TOC19/TOC19/Settings.java
+++ b/src/TOC19/TOC19/Settings.java
@@ -5,9 +5,11 @@
  */
 package TOC19;
 
+import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.file.Paths;
 import java.util.Properties;
 
 /*
@@ -37,9 +39,24 @@ import java.util.Properties;
 
 class Settings {
 	private final Properties properties = new Properties();
-	private final String propFileName = "TOC19.properties";
-	private final InputStream inputStream = getClass().getClassLoader().getResourceAsStream(propFileName);
-	
+	private final String propFileName = Compatibility.getFilePath("TOC19.properties");
+	private InputStream inputStream = this.getClass().getClassLoader().getResourceAsStream(propFileName);
+
+	public Settings() {
+		if (inputStream != null) return;
+
+		try {
+			if (inputStream == null){
+				inputStream = new FileInputStream(String.valueOf(Paths.get(propFileName)));
+			}
+			if (inputStream == null){
+				throw new FileNotFoundException("property file '" + propFileName + "' not found in the classpath");
+			}
+		} catch (FileNotFoundException e) {
+			e.printStackTrace();
+		}
+	}
+
 	public final String adminSettings() throws FileNotFoundException
 	{
 		if (inputStream != null) {


### PR DESCRIPTION
The program now checks if the system reports itself as Windows, if so it uses the absolute path to the file instead of the relative path.

To maintain compatibility future file reading operations should be directed through the Compatibility class.
